### PR TITLE
✨ Add --exclusions Flag to osv-scanner CLI

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -144,6 +144,18 @@ Then pass this to `osv-scanner` with this:
 osv-scanner --lockfile osv-scanner:/path/to/osv-scanner.json
 ```
 
+## Specify Package(s) to Exclude from OSV Query
+
+If you want to exclude a package or a range of packages from the query to the OSV database, you can pass a list of regex patterns with the '--exclude-packages' flag. OSV-Scanner will check for packages matching the specified regex patterns and exclude these packages from being checked for known vulnerabilities. The exclusions apply to both lockfile specified packages and SBOM specified packages.
+
+The exclusion regex patterns can be applied with the following flag:
+
+```bash
+osv-scanner --exclude-packages='^example.com/.*,^react$' <rest-of-cli-interaction>
+```
+
+Please note! It is best practice to specify the regex patterns in single quotes to avoid shell expansion of the regex patterns.
+
 ## Scanning a Debian based docker image packages
 Preview
 {: .label }

--- a/internal/cachedregexp/regex.go
+++ b/internal/cachedregexp/regex.go
@@ -15,3 +15,17 @@ func MustCompile(exp string) *regexp.Regexp {
 
 	return compiled.(*regexp.Regexp)
 }
+
+// Compile compiles a regular expression and caches it.
+func Compile(exp string) (*regexp.Regexp, error) {
+	compiled, ok := cache.Load(exp)
+	if !ok {
+		re, err := regexp.Compile(exp)
+		if err != nil {
+			return nil, err
+		}
+		compiled, _ = cache.LoadOrStore(exp, re)
+	}
+
+	return compiled.(*regexp.Regexp), nil
+}

--- a/internal/exclusions/exclusions.go
+++ b/internal/exclusions/exclusions.go
@@ -1,0 +1,86 @@
+package exclusions
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/google/osv-scanner/internal/cachedregexp"
+	"github.com/google/osv-scanner/internal/sbom"
+	"github.com/google/osv-scanner/pkg/lockfile"
+	"github.com/google/osv-scanner/pkg/reporter"
+)
+
+// ExcludePackages checks for matches in a Lockfile's Packages against the list of provided exclusion regex patterns.
+// If a match is found, the package is removed from the Lockfile's Packages.
+// The updated Lockfile is returned.
+func ExcludePackages(r reporter.Reporter, exclusionRegexes []*regexp.Regexp, parsedLockfile *lockfile.Lockfile) (*lockfile.Lockfile, error) {
+	filteredPackages := make([]lockfile.PackageDetails, 0)
+
+	for _, pkg := range parsedLockfile.Packages {
+		matched := checkForRegexMatch(r, exclusionRegexes, pkg.Name)
+		if matched {
+			continue
+		}
+		filteredPackages = append(filteredPackages, pkg)
+	}
+	parsedLockfile.Packages = filteredPackages
+
+	return parsedLockfile, nil
+}
+
+// ExcludeSBOMPackages checks if SBOM's ID matches the list of provided exclusion regex patterns.
+// If a match is found, the SBOM PURL is excluded from the OSV query by returning a boolean value of true to the calling scanSBOMFile function.
+func ExcludeSBOMPackages(r reporter.Reporter, exclusionRegexes []*regexp.Regexp, id *sbom.Identifier) (bool, error) {
+	matched := checkForRegexMatch(r, exclusionRegexes, id.PURL)
+	if matched {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// IsRegexPatterns checks if a list of regex patterns are valid regex patterns.
+func IsRegexPatterns(patterns []string) error {
+	for _, pattern := range patterns {
+		if !isValidRegex(pattern) {
+			return fmt.Errorf("%s", pattern)
+		}
+	}
+
+	return nil
+}
+
+// ParseExclusions parses a list of regex patterns into a list of regex objects.
+func ParseExclusions(patterns []string) ([]*regexp.Regexp, error) {
+	exclusionRegexes := make([]*regexp.Regexp, len(patterns))
+	for i, pattern := range patterns {
+		re, err := cachedregexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid exclusion pattern: %w", err)
+		}
+		exclusionRegexes[i] = re
+	}
+
+	return exclusionRegexes, nil
+}
+
+func checkForRegexMatch(r reporter.Reporter, exclusionRegexes []*regexp.Regexp, pkg string) bool {
+	for _, re := range exclusionRegexes {
+		matched := false
+		if re.MatchString(pkg) {
+			r.PrintText(fmt.Sprintf("Regex Match Found for exclusion pattern: '%s'\n", re.String()))
+			r.PrintText(fmt.Sprintf("Excluding package from OSV query: %s\n", pkg))
+			matched = true
+		}
+		if matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isValidRegex(pattern string) bool {
+	_, err := cachedregexp.Compile(pattern)
+	return err == nil
+}

--- a/internal/exclusions/exclusions_test.go
+++ b/internal/exclusions/exclusions_test.go
@@ -1,0 +1,220 @@
+package exclusions_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/osv-scanner/internal/exclusions"
+	"github.com/google/osv-scanner/internal/sbom"
+	"github.com/google/osv-scanner/pkg/lockfile"
+	"github.com/google/osv-scanner/pkg/models"
+)
+
+type MockReporter struct {
+	Output []string
+	Error  []string
+}
+
+func (r *MockReporter) PrintText(text string) {
+	r.Output = append(r.Output, text)
+}
+func (r *MockReporter) PrintError(text string) {
+	r.Error = append(r.Error, text)
+}
+
+func (r *MockReporter) HasPrintedError() bool {
+	return r.Error != nil
+}
+func (r *MockReporter) PrintResult(vulnResult *models.VulnerabilityResults) error {
+	return nil
+}
+
+func TestExcludePackages(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		name                 string
+		lockfileData         []lockfile.PackageDetails
+		exclusionPatterns    []string
+		expectedLockfileData []lockfile.PackageDetails
+		wantErr              bool
+		outputText           []string
+		errorText            []string
+	}
+	tests := []testCase{
+		{
+			name:                 "Package matches regex pattern",
+			lockfileData:         []lockfile.PackageDetails{{Name: "package1"}, {Name: "package2"}, {Name: "package3"}},
+			exclusionPatterns:    []string{"package1"},
+			expectedLockfileData: []lockfile.PackageDetails{{Name: "package2"}, {Name: "package3"}},
+			wantErr:              false,
+			outputText:           []string{"Regex Match Found for exclusion pattern: 'package1'\n", "Excluding package from OSV query: package1\n"},
+			errorText:            nil,
+		},
+		{
+			name:                 "Multiple packages matches regex pattern",
+			lockfileData:         []lockfile.PackageDetails{{Name: "package1"}, {Name: "package2"}, {Name: "somethingDifferent"}},
+			exclusionPatterns:    []string{".*package.*"},
+			expectedLockfileData: []lockfile.PackageDetails{{Name: "somethingDifferent"}},
+			wantErr:              false,
+			outputText:           []string{"Regex Match Found for exclusion pattern: '.*package.*'\n", "Excluding package from OSV query: package1\n", "Regex Match Found for exclusion pattern: '.*package.*'\n", "Excluding package from OSV query: package2\n"},
+			errorText:            nil,
+		},
+		{
+			name:                 "No packages match regex pattern",
+			lockfileData:         []lockfile.PackageDetails{{Name: "package1"}, {Name: "package2"}, {Name: "package3"}},
+			exclusionPatterns:    []string{"package4"},
+			expectedLockfileData: []lockfile.PackageDetails{{Name: "package1"}, {Name: "package2"}, {Name: "package3"}},
+			wantErr:              false,
+			outputText:           nil,
+			errorText:            nil,
+		},
+		{
+			name:                 "Invalid regex pattern",
+			lockfileData:         []lockfile.PackageDetails{{Name: "package1"}, {Name: "package2"}, {Name: "package3"}},
+			exclusionPatterns:    []string{"*hello*"},
+			expectedLockfileData: []lockfile.PackageDetails{{Name: "package1"}, {Name: "package2"}, {Name: "package3"}},
+			wantErr:              false,
+			outputText:           nil,
+			errorText:            []string{"invalid exclusion pattern: error parsing regexp: missing argument to repetition operator: `*`"},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mockReporter := &MockReporter{}
+			lockfile := lockfile.Lockfile{Packages: tt.lockfileData}
+			parseExclusions, err := exclusions.ParseExclusions(tt.exclusionPatterns)
+			if err != nil {
+				mockReporter.PrintError(err.Error())
+			}
+			filteredLockfile, err := exclusions.ExcludePackages(mockReporter, parseExclusions, &lockfile)
+
+			if !cmp.Equal(err != nil, tt.wantErr) {
+				t.Errorf("ExcludePackages returned an unexpected error: %v", err)
+			}
+
+			for i, pkg := range filteredLockfile.Packages {
+				if !cmp.Equal(pkg.Name, tt.expectedLockfileData[i].Name) {
+					t.Errorf("ExcludePackages did not filter the packages as expected. Got: %v, Want: %v", filteredLockfile.Packages, tt.expectedLockfileData)
+				}
+			}
+
+			if !cmp.Equal(mockReporter.Output, tt.outputText) {
+				t.Errorf("ExcludePackages did not print the expected output. Got: %v, Want: %v", mockReporter.Output, tt.outputText)
+			}
+
+			if !cmp.Equal(mockReporter.Error, tt.errorText) {
+				t.Errorf("ExcludePackages did not print the expected error. Got: %v, Want: %v", mockReporter.Error, tt.errorText)
+			}
+		})
+	}
+}
+
+func TestExcludeSBOMPackages(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		name              string
+		SBOMData          sbom.Identifier
+		exclusionPatterns []string
+		wantMatch         bool
+		wantErr           bool
+		outputText        []string
+		errorText         []string
+	}
+
+	tests := []testCase{
+		{
+			name:              "Package matches regex pattern",
+			SBOMData:          sbom.Identifier{PURL: "package1"},
+			exclusionPatterns: []string{".*package.*"},
+			wantMatch:         true,
+			wantErr:           false,
+			outputText:        []string{"Regex Match Found for exclusion pattern: '.*package.*'\n", "Excluding package from OSV query: package1\n"},
+			errorText:         nil,
+		},
+		{
+			name:              "No packages match regex pattern",
+			SBOMData:          sbom.Identifier{PURL: "package1"},
+			exclusionPatterns: []string{"somethingDifferent"},
+			wantMatch:         false,
+			wantErr:           false,
+			outputText:        nil,
+			errorText:         nil,
+		},
+		{
+			name:              "Invalid regex pattern",
+			SBOMData:          sbom.Identifier{PURL: "package1"},
+			exclusionPatterns: []string{"*hello*"},
+			wantMatch:         false,
+			wantErr:           false,
+			outputText:        nil,
+			errorText:         []string{"invalid exclusion pattern: error parsing regexp: missing argument to repetition operator: `*`"},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mockReporter := &MockReporter{}
+			parsedExclusions, err := exclusions.ParseExclusions(tt.exclusionPatterns)
+			if err != nil {
+				mockReporter.PrintError(err.Error())
+			}
+			match, err := exclusions.ExcludeSBOMPackages(mockReporter, parsedExclusions, &tt.SBOMData)
+
+			if !cmp.Equal(match, tt.wantMatch) {
+				t.Errorf("Expected match: %v, got match: %v", tt.wantMatch, match)
+			}
+
+			if !cmp.Equal(err != nil, tt.wantErr) {
+				t.Errorf("Expected error: %v, got error: %v", tt.wantErr, err)
+			}
+
+			if !cmp.Equal(mockReporter.Output, tt.outputText) {
+				t.Errorf("ExcludeSBOMPackages did not print the expected output. Got: %v, Want: %v", mockReporter.Output, tt.outputText)
+			}
+
+			if !cmp.Equal(mockReporter.Error, tt.errorText) {
+				t.Errorf("ExcludeSBOMPackages did not print the expected error. Got: %v, Want: %v", mockReporter.Error, tt.errorText)
+			}
+		})
+	}
+}
+
+func TestIsRegexPatterns(t *testing.T) {
+	t.Parallel()
+	type testCase struct {
+		name    string
+		pattern []string
+		want    bool
+	}
+	testCases := []testCase{
+		{
+			name:    "Single valid regex pattern",
+			pattern: []string{".*aValidPattern"},
+			want:    false,
+		},
+		{
+			name:    "Multiple valid regex patterns",
+			pattern: []string{".*aValidPattern", "another_valid_{r1}egex"},
+			want:    false,
+		},
+		{
+			name:    "Invalid regex pattern",
+			pattern: []string{"*myInvalidPattern*["},
+			want:    true,
+		},
+	}
+
+	for _, tt := range testCases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := exclusions.IsRegexPatterns(tt.pattern)
+			if (err != nil) != tt.want {
+				t.Errorf("IsRegexPatterns() for pattern %s = %v; want %v", tt.pattern, err, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a --exclusions flag to the osv-scanner CLI. This flag allows users to specify a list of regex patterns to which matches of collected package names will be matched against.

If the packages are found to match the regex patterns, they will be excluded from the query to the OSV database.

This the exlusions work for both lockfile and SBOM package definitions.